### PR TITLE
LPS-106251 | LPS-106288 | LPS-106245 | LPS-106278 Revert

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.segments.constants.SegmentsEntryConstants;
@@ -196,9 +195,9 @@ public class SegmentResourceTest extends BaseSegmentResourceTestCase {
 
 		return _toSegment(
 			SegmentsTestUtil.addSegmentsEntry(
-				segment.getName(), segment.getName(),
-				RandomTestUtil.randomString(), segment.getCriteria(),
-				segment.getSource(), User.class.getName(), serviceContext));
+				segment.getName(), segment.getName(), null,
+				segment.getCriteria(), segment.getSource(),
+				User.class.getName(), serviceContext));
 	}
 
 	private Segment _toSegment(SegmentsEntry segmentsEntry) {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
@@ -344,8 +344,8 @@ public class SegmentsEntryLocalServiceTest {
 
 		BaseModelSearchResult<SegmentsEntry> baseModelSearchResult =
 			_segmentsEntryLocalService.searchSegmentsEntries(
-				segmentsEntry1.getCompanyId(), segmentsEntry1.getGroupId(), "",
-				true, params, 0, 1, null);
+				segmentsEntry1.getCompanyId(), segmentsEntry1.getGroupId(),
+				null, true, params, 0, 1, null);
 
 		List<SegmentsEntry> segmentsEntries =
 			baseModelSearchResult.getBaseModels();
@@ -377,7 +377,7 @@ public class SegmentsEntryLocalServiceTest {
 
 		BaseModelSearchResult<SegmentsEntry> baseModelSearchResult =
 			_segmentsEntryLocalService.searchSegmentsEntries(
-				segmentsEntry.getCompanyId(), segmentsEntry.getGroupId(), "",
+				segmentsEntry.getCompanyId(), segmentsEntry.getGroupId(), null,
 				true, params, 0, 1, null);
 
 		List<SegmentsEntry> segmentsEntries =
@@ -404,7 +404,7 @@ public class SegmentsEntryLocalServiceTest {
 
 		BaseModelSearchResult<SegmentsEntry> baseModelSearchResult =
 			_segmentsEntryLocalService.searchSegmentsEntries(
-				segmentsEntry.getCompanyId(), segmentsEntry.getGroupId(), "",
+				segmentsEntry.getCompanyId(), segmentsEntry.getGroupId(), null,
 				true, params, 0, 1, null);
 
 		List<SegmentsEntry> segmentsEntries =

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -354,7 +354,7 @@ public class EditSegmentsEntryDisplayContext {
 		SegmentsEntry segmentsEntry = _getSegmentsEntry();
 
 		if (segmentsEntry == null) {
-			return JSONFactoryUtil.createJSONObject();
+			return null;
 		}
 
 		JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -70,6 +70,7 @@ class SegmentEdit extends Component {
 		contributors: [],
 		handleBlur: () => {},
 		initialSegmentActive: true,
+		initialSegmentName: {},
 		portletNamespace: '',
 		showInEditMode: false
 	};

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/util/SegmentsExperimentUtil.java
@@ -16,7 +16,6 @@ package com.liferay.segments.experiment.web.internal.util;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -104,7 +103,7 @@ public class SegmentsExperimentUtil {
 		throws PortalException {
 
 		if (segmentsExperiment == null) {
-			return JSONFactoryUtil.createJSONObject();
+			return null;
 		}
 
 		return JSONUtil.put(

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/context.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/state/context.es.js
@@ -34,10 +34,7 @@ export function getInitialState(firstState) {
 	} = firstState;
 
 	const state = {
-		experiment:
-			Object.keys(initialSegmentsExperiment).length === 0
-				? null
-				: initialSegmentsExperiment,
+		experiment: initialSegmentsExperiment,
 		experimentHistory: initialExperimentHistory || [],
 		selectedExperienceId: initialSelectedSegmentsExperienceId,
 		variants: initialSegmentsVariants.map(initialVariant => {

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/renderApp.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/renderApp.es.js
@@ -22,7 +22,7 @@ export default function renderApp({
 	initialGoals = segmentsGoals,
 	initialExperimentHistory = [],
 	initialSegmentsExperiences = [],
-	initialSegmentsExperiment = {},
+	initialSegmentsExperiment,
 	initialSegmentsVariants = [],
 	APIService = {},
 	selectedSegmentsExperienceId,


### PR DESCRIPTION
Revert these PRs:
- https://github.com/brianchandotcom/liferay-portal/pull/82403
- https://github.com/brianchandotcom/liferay-portal/pull/82428
- https://github.com/brianchandotcom/liferay-portal/pull/82407
- https://github.com/brianchandotcom/liferay-portal/pull/82432

Since @hhuijser reverted his changes:
- https://github.com/brianchandotcom/liferay-portal/pull/82424

Hugo's PR causes LPS-106251, LPS-106288, LPS-106245, and LPS-106278. HashMapBuilder didn't allow the `null` parameter. Maybe in the future, if Hugo's change goes back to master, we can talk about how to resolve it together.

/cc @epgarcia @andresfulla @hhuijser @darquesdev