### PR TITLE
LPS-112924 Don't show views number if the content was published today

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
@@ -43,13 +43,16 @@ export default function ({context, props}) {
 		page,
 	});
 
+	const publishedToday =
+		new Date().toDateString() === new Date(publishDate).toDateString();
+
 	return (
 		<ConnectionContext.Provider
 			value={{
 				validAnalyticsConnection,
 			}}
 		>
-			<StoreContextProvider value={{readsEnabled}}>
+			<StoreContextProvider value={{publishedToday, readsEnabled}}>
 				<Navigation
 					api={api}
 					authorName={authorName}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -26,7 +26,7 @@ import {
 } from 'recharts';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext, useWarning} from '../context/store';
+import {StoreContext, useHistoricalWarning} from '../context/store';
 import {useChartState} from '../state/chartState';
 import {generateDateFormatters as dateFormat} from '../utils/dateFormat';
 import {numberFormat} from '../utils/numberFormat';
@@ -140,7 +140,7 @@ export default function Chart({
 }) {
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
-	const [hasWarning, addWarning] = useWarning();
+	const [hasHistoricalWarning, addHistoricalWarning] = useHistoricalWarning();
 
 	const [{readsEnabled}] = useContext(StoreContext);
 
@@ -193,8 +193,8 @@ export default function Chart({
 							key = 'analyticsReportsHistoricalViews';
 						}
 
-						if (!hasWarning) {
-							addWarning();
+						if (!hasHistoricalWarning) {
+							addHistoricalWarning();
 						}
 
 						actions.addDataSetItem({
@@ -332,11 +332,15 @@ export default function Chart({
 						/>
 					)}
 
-					{validAnalyticsConnection && publishedToday && (
-						<div className={publishedTodayClasses}>
-							{Liferay.Language.get('no-data-is-available-yet')}
-						</div>
-					)}
+					{validAnalyticsConnection &&
+						publishedToday &&
+						!hasHistoricalWarning && (
+							<div className={publishedTodayClasses}>
+								{Liferay.Language.get(
+									'no-data-is-available-yet'
+								)}
+							</div>
+						)}
 
 					{title && <h5>{title}</h5>}
 
@@ -348,7 +352,9 @@ export default function Chart({
 						>
 							<CartesianGrid
 								horizontalPoints={
-									validAnalyticsConnection && publishedToday
+									validAnalyticsConnection &&
+									publishedToday &&
+									!hasHistoricalWarning
 										? [CHART_SIZES.dotRadius]
 										: []
 								}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Chart.js
@@ -104,6 +104,7 @@ function thousandsToKilosFormater(value) {
 function legendFormatterGenerator(
 	totals,
 	languageTag,
+	publishedToday,
 	validAnalyticsConnection
 ) {
 	return (value) => {
@@ -121,7 +122,9 @@ function legendFormatterGenerator(
 					{keyToTranslatedLabelValue(value)}
 				</span>
 				<span className="font-weight-bold">
-					{validAnalyticsConnection && preformattedNumber !== null
+					{validAnalyticsConnection &&
+					preformattedNumber !== null &&
+					!publishedToday
 						? numberFormat(languageTag, preformattedNumber)
 						: '-'}
 				</span>
@@ -142,7 +145,7 @@ export default function Chart({
 
 	const [hasHistoricalWarning, addHistoricalWarning] = useHistoricalWarning();
 
-	const [{readsEnabled}] = useContext(StoreContext);
+	const [{publishedToday, readsEnabled}] = useContext(StoreContext);
 
 	const {actions, state: chartState} = useChartState({
 		defaultTimeSpanOption,
@@ -150,9 +153,6 @@ export default function Chart({
 	});
 
 	const isMounted = useIsMounted();
-
-	const publishedToday =
-		new Date().toDateString() === new Date(publishDate).toDateString();
 
 	useEffect(() => {
 		let gone = false;
@@ -290,6 +290,7 @@ export default function Chart({
 		legendFormatterGenerator(
 			dataSet.totals,
 			languageTag,
+			publishedToday,
 			validAnalyticsConnection
 		);
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Navigation.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useCallback, useContext, useState} from 'react';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {StoreContext, useWarning} from '../context/store';
+import {StoreContext, useHistoricalWarning, useWarning} from '../context/store';
 import {numberFormat} from '../utils/numberFormat';
 import Detail from './Detail';
 import Main from './Main';
@@ -37,6 +37,8 @@ export default function Navigation({
 	const {validAnalyticsConnection} = useContext(ConnectionContext);
 
 	const [hasWarning] = useWarning();
+
+	const [hasHistoricalWarning] = useHistoricalWarning();
 
 	const {getHistoricalReads, getHistoricalViews} = api;
 
@@ -116,7 +118,7 @@ export default function Navigation({
 				</ClayAlert>
 			)}
 
-			{validAnalyticsConnection && hasWarning && (
+			{validAnalyticsConnection && (hasWarning || hasHistoricalWarning) && (
 				<ClayAlert
 					className="p-0"
 					displayType="warning"

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TotalCount.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
 import ConnectionContext from '../context/ConnectionContext';
-import {useWarning} from '../context/store';
+import {StoreContext, useWarning} from '../context/store';
 import Hint from './Hint';
 
 function TotalCount({
@@ -34,6 +34,8 @@ function TotalCount({
 	const isMounted = useIsMounted();
 
 	const [, addWarning] = useWarning();
+
+	const [{publishedToday}] = useContext(StoreContext);
 
 	useEffect(() => {
 		if (validAnalyticsConnection) {
@@ -55,7 +57,7 @@ function TotalCount({
 
 	let displayValue = '-';
 
-	if (validAnalyticsConnection) {
+	if (validAnalyticsConnection && !publishedToday) {
 		displayValue =
 			percentage && value !== '-' ? <span>{`${value}%`}</span> : value;
 	}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
@@ -19,6 +19,7 @@ const INITIAL_STATE = {
 };
 
 const ADD_WARNING = 'add-warning';
+const ADD_HISTORICAL_WARNING = 'add-historical-warning';
 
 export const StoreContext = createContext([INITIAL_STATE, () => {}]);
 
@@ -27,6 +28,12 @@ function reducer(state = INITIAL_STATE, action) {
 		return {
 			...state,
 			warning: true,
+		};
+	}
+	else if (action.type === ADD_HISTORICAL_WARNING) {
+		return {
+			...state,
+			historicalWarning: true,
 		};
 	}
 
@@ -41,6 +48,20 @@ export function StoreContextProvider({children, value}) {
 			{children}
 		</StoreContext.Provider>
 	);
+}
+
+export function useHistoricalWarning() {
+	const [state, dispatch] = useContext(StoreContext);
+
+	const addHistoricalWarning = useCallback(() => {
+		dispatch({
+			type: ADD_HISTORICAL_WARNING,
+		});
+	}, [dispatch]);
+
+	const hasHistoricalWarning = state.historicalWarning;
+
+	return [hasHistoricalWarning, addHistoricalWarning];
 }
 
 export function useWarning() {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/context/store.js
@@ -11,7 +11,12 @@
 
 import React, {createContext, useCallback, useContext, useReducer} from 'react';
 
-const INITIAL_STATE = {readsEnabled: true, warning: false};
+const INITIAL_STATE = {
+	historicalWarning: false,
+	publishedToday: false,
+	readsEnabled: true,
+	warning: false,
+};
 
 const ADD_WARNING = 'add-warning';
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Chart.js
@@ -14,6 +14,7 @@ import {cleanup, render, wait} from '@testing-library/react';
 import React from 'react';
 
 import Chart from '../../../src/main/resources/META-INF/resources/js/components/Chart';
+import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/store';
 
 const mockReadsDataProvider = jest.fn(() =>
 	Promise.resolve({
@@ -226,14 +227,19 @@ describe('Chart', () => {
 		};
 
 		const {getByText} = render(
-			<Chart
-				dataProviders={[mockViewsDataProvider, mockReadsDataProvider]}
-				defaultTimeRange={testProps.defaultTimeRange}
-				defaultTimeSpanOption={testProps.defaultTimeSpanOption}
-				languageTag={testProps.languageTag}
-				publishDate={testProps.publishDate}
-				timeSpanOptions={mockTimeSpanOptions}
-			/>
+			<StoreContextProvider value={{publishedToday: true}}>
+				<Chart
+					dataProviders={[
+						mockViewsDataProvider,
+						mockReadsDataProvider,
+					]}
+					defaultTimeRange={testProps.defaultTimeRange}
+					defaultTimeSpanOption={testProps.defaultTimeSpanOption}
+					languageTag={testProps.languageTag}
+					publishDate={testProps.publishDate}
+					timeSpanOptions={mockTimeSpanOptions}
+				/>
+			</StoreContextProvider>
 		);
 
 		await wait(() =>


### PR DESCRIPTION
If the content was published today, we don't have any information yet about views metrics so the total views number and the number of views in the legend of the chart will be: "-".