### PR TITLE
LPS-113876 &  LPS-114341

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/build.gradle
+++ b/modules/apps/content-dashboard/content-dashboard-web/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/build.gradle
+++ b/modules/apps/content-dashboard/content-dashboard-web/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"react": "16.12.0"
+	},
+	"name": "content-dashboard-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,10 +14,11 @@
  */
 --%>
 
-<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <liferay-theme:defineObjects />
 
-<portlet:defineObjects />
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/AuditGraphApp.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/AuditGraphApp.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,14 +11,9 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+import React from 'react';
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
-
-<liferay-theme:defineObjects />
-
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+export default function () {
+	return <></>;
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -21,6 +21,16 @@
 >
 	<div class="sheet">
 		<h2 class="sheet-title">
+			<%= LanguageUtil.format(request, "number-of-contents-per-audience-and-stage-x", 0, false) %>
+		</h2>
+	</div>
+</clay:container>
+
+<clay:container
+	className="main-content-body"
+>
+	<div class="sheet">
+		<h2 class="sheet-title">
 			<%= LanguageUtil.format(request, "content-x", 0, false) %>
 		</h2>
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,6 +23,16 @@
 		<h2 class="sheet-title">
 			<%= LanguageUtil.format(request, "number-of-contents-per-audience-and-stage-x", 0, false) %>
 		</h2>
+
+		<div id="audit-graph">
+			<div class="inline-item my-5 p-5 w-100">
+				<span aria-hidden="true" class="loading-animation"></span>
+			</div>
+
+			<react:component
+				module="js/AuditGraphApp"
+			/>
+		</div>
 	</div>
 </clay:container>
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -15,3 +15,27 @@
 --%>
 
 <%@ include file="/init.jsp" %>
+
+<clay:container
+	className="main-content-body"
+>
+	<div class="sheet">
+		<h2 class="sheet-title">
+			<%= LanguageUtil.format(request, "content-x", 0, false) %>
+		</h2>
+
+		<c:choose>
+			<c:when test="<%= true %>">
+				<div class="taglib-empty-result-message">
+					<div class="taglib-empty-result-message-header"></div>
+
+					<div class="sheet-text text-center">
+						<%= LanguageUtil.get(request, "there-are-no-contents") %>
+					</div>
+				</div>
+			</c:when>
+			<c:otherwise>
+			</c:otherwise>
+		</c:choose>
+	</div>
+</clay:container>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard
+content-x=Content ({0})
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard
+there-are-no-contents=There are no contents.

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard
 content-x=Content ({0})
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0})
 there-are-no-contents=There are no contents.

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
@@ -1,2 +1,4 @@
 content-dashboard=لوحة معلومات المحتويات
+content-x=Content ({0}) (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=لوحة معلومات المحتويات

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ar.properties
@@ -1,4 +1,5 @@
 content-dashboard=لوحة معلومات المحتويات
 content-x=Content ({0}) (Automatic Copy)
-there-are-no-contents=There are no contents. (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=لوحة معلومات المحتويات
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_bg.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
@@ -1,2 +1,4 @@
 content-dashboard=Tauler de contingut
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tauler de contingut
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ca.properties
@@ -1,4 +1,5 @@
 content-dashboard=Tauler de contingut
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tauler de contingut
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_cs.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_da.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
@@ -1,2 +1,4 @@
 content-dashboard=Inhalts-Dashboard
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Inhalts-Dashboard
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_de.properties
@@ -1,4 +1,5 @@
 content-dashboard=Inhalts-Dashboard
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Inhalts-Dashboard
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_el.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard
+content-x=Content ({0})
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard
+there-are-no-contents=There are no contents.

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard
 content-x=Content ({0})
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0})
 there-are-no-contents=There are no contents.

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_AU.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_en_GB.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
@@ -1,2 +1,4 @@
 content-dashboard=Panel de contenido
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Panel de contenido
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_es.properties
@@ -1,4 +1,5 @@
 content-dashboard=Panel de contenido
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Panel de contenido
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_et.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_eu.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fa.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
@@ -1,2 +1,4 @@
 content-dashboard=Sisällön Koontinäyttö
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Sisällön Koontinäyttö
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fi.properties
@@ -1,4 +1,5 @@
 content-dashboard=Sisällön Koontinäyttö
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Sisällön Koontinäyttö
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
@@ -1,2 +1,4 @@
 content-dashboard=Tableau de bord du contenu
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tableau de bord du contenu
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr.properties
@@ -1,4 +1,5 @@
 content-dashboard=Tableau de bord du contenu
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tableau de bord du contenu
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_gl.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hr.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
@@ -1,2 +1,4 @@
 content-dashboard=Tartalom műszerfal
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tartalom műszerfal
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_hu.properties
@@ -1,4 +1,5 @@
 content-dashboard=Tartalom műszerfal
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Tartalom műszerfal
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_in.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_it.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_iw.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
@@ -1,2 +1,4 @@
 content-dashboard=コンテンツダッシュボード
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=コンテンツダッシュボード
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ja.properties
@@ -1,4 +1,5 @@
 content-dashboard=コンテンツダッシュボード
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=コンテンツダッシュボード
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_kk.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ko.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lo.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_lt.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nb.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
@@ -1,2 +1,4 @@
 content-dashboard=Inhouddashboard
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Inhouddashboard
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl.properties
@@ -1,4 +1,5 @@
 content-dashboard=Inhouddashboard
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Inhouddashboard
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pl.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,2 +1,4 @@
 content-dashboard=Painel de conteúdo
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Painel de conteúdo
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,4 +1,5 @@
 content-dashboard=Painel de conteúdo
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Painel de conteúdo
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ro.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ru.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sk.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sl.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
@@ -1,2 +1,4 @@
 content-dashboard=Instrumentpanel för innehåll
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Instrumentpanel för innehåll
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_sv.properties
@@ -1,4 +1,5 @@
 content-dashboard=Instrumentpanel för innehåll
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Instrumentpanel för innehåll
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_th.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_tr.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_uk.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_vi.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,2 +1,4 @@
 content-dashboard=内容仪表板
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=内容仪表板
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,4 +1,5 @@
 content-dashboard=内容仪表板
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=内容仪表板
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,2 +1,4 @@
 content-dashboard=Content Dashboard (Automatic Copy)
+content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+there-are-no-contents=There are no contents. (Automatic Copy)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,4 +1,5 @@
 content-dashboard=Content Dashboard (Automatic Copy)
 content-x=Content ({0}) (Automatic Copy)
 javax.portlet.title.com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet=Content Dashboard (Automatic Copy)
+number-of-contents-per-audience-and-stage-x=Number of Contents per Audience and Stage ({0}) (Automatic Copy)
 there-are-no-contents=There are no contents. (Automatic Copy)


### PR DESCRIPTION
Content Dashboard has two pieces of content: one for Audit Graph and the other for search-container list. The desire framework to implement the Audit Graph is @clayui/charts, so we need to inject a React app in the `view.jsp` file.

<img width="559" alt="Screenshot 2020-05-26 at 14 18 33" src="https://user-images.githubusercontent.com/15845466/82899771-cf7ae700-9f5b-11ea-8791-bd5579719159.png">

In this pull request there is the structure of those two pieces (two `<div>` with "sheet" class) and the React app (empty for now) to display the Chart in the future.

Thanks.