### PR TITLE
LPS-116539 Possible fix for "value" collisions

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -37,3 +37,8 @@
 		stroke-opacity: 0;
 	}
 }
+
+.custom-tooltip {
+	box-shadow: 0 1px 15px -2px rgba(0, 0, 0, 0.2);
+	opacity: 1;
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -23,6 +23,7 @@ import {
 	CartesianGrid,
 	Legend,
 	Text,
+	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts';
@@ -179,6 +180,8 @@ export default function AuditBarChart({rtl, vocabularies}) {
 		(i) => checkboxes[i] === false
 	);
 
+	const [tooltip, setTooltip] = useState(null);
+
 	return (
 		<>
 			{Object.keys(checkboxes).length > 0 && noCheckboxesChecked && (
@@ -235,6 +238,11 @@ export default function AuditBarChart({rtl, vocabularies}) {
 						tickLine={false}
 						width={45}
 					/>
+					<Tooltip
+						content={<CustomTooltip />}
+						cursor={{fill: 'transparent'}}
+						tooltip={tooltip}
+					/>
 					{bars.length &&
 						bars.map((bar, index) => {
 							return (
@@ -250,6 +258,12 @@ export default function AuditBarChart({rtl, vocabularies}) {
 									key={index}
 									legendType="square"
 									name={bar.name}
+									onMouseOut={() => {
+										setTooltip(null);
+									}}
+									onMouseOver={() => {
+										setTooltip(bar.dataKey);
+									}}
 								/>
 							);
 						})}
@@ -258,12 +272,47 @@ export default function AuditBarChart({rtl, vocabularies}) {
 							barSize={BAR_CHART.barHeight}
 							dataKey="value"
 							fill={COLORS[0]}
+							onMouseOut={() => {
+								setTooltip(null);
+							}}
+							onMouseOver={() => {
+								setTooltip('value');
+							}}
 						/>
 					)}
 				</BarChart>
 			</div>
 		</>
 	);
+}
+
+function CustomTooltip(props) {
+	const {active, label, payload, tooltip} = props;
+
+	if (!active || !tooltip) {
+		return null;
+	}
+
+	for (var i = 0; i <= payload.length; i++) {
+		if (payload[i].dataKey === tooltip) {
+			return (
+				<ClayLayout.ContentRow
+					className="bg-white custom-tooltip p-1 rounded small text-secondary"
+					padded
+					style={{width: 150}}
+				>
+					<ClayLayout.ContentCol expand>
+						{tooltip === 'value' ? label : payload[i].name}
+					</ClayLayout.ContentCol>
+					<ClayLayout.ContentCol>
+						{payload[i].value}
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
+			);
+		}
+	}
+
+	return null;
 }
 
 function CustomXAxisTick(props) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditBarChart.js
@@ -302,7 +302,9 @@ function CustomTooltip(props) {
 					style={{width: 150}}
 				>
 					<ClayLayout.ContentCol expand>
-						{tooltip === 'value' ? label : payload[i].name}
+						{payload[i].payload.vocabularyName
+							? label
+							: payload[i].name}
 					</ClayLayout.ContentCol>
 					<ClayLayout.ContentCol>
 						{payload[i].value}


### PR DESCRIPTION
@dgarciasarai: I think this might work? See [the commit](https://github.com/dgarciasarai/liferay-portal/commit/34a1aadabb282ba55f5ac804ec8246a19c2e039a) on top of [your PR](https://github.com/liferay-frontend/liferay-portal/pull/80) (also, it's rebased, but that shouldn't make any difference.

1. No stages: `tooltip` is "value", array is length 1, `payload[0].vocabularyName` is set; we want to use `label` (ie. "Some human readable audience") as opposed to `payload[i].name` (ie. "value").
2. One or more stages: array length is 1 or more, but this time `payload[i].name` has a reasonable value (eg. "Some human readable stage"); `payload[i].vocabularyName` is not set.

This seems less likely to collide than `value` might, as per [our comment thread](https://github.com/liferay-frontend/liferay-portal/pull/80#discussion_r450773248).

## Previous PR description:

**Description**

The main goal of this pull request is to show the total number of contents when hovering on a bar

**Feature flag: YES**

The Audit Graph is hidden. The configuration file to show the chart is here: https://issues.liferay.com/browse/LPS-115805

**Module**

```
~/liferay-portal/modules/apps/content-dashboard/content-dashboard-web
```

**Screenshots**

<img width="1240" alt="Screenshot 2020-07-07 at 12 01 08" src="https://user-images.githubusercontent.com/15845466/86766125-60a8a780-c04a-11ea-860b-caa713f9d5f6.png">

<img width="1244" alt="Screenshot 2020-07-07 at 17 20 20" src="https://user-images.githubusercontent.com/15845466/86803318-29e88680-c076-11ea-8680-300a081e7e2e.png">

cc: @bryceosterhaus @wincent @eduardoallegrini